### PR TITLE
Encoding of arguments was turning a string into a char array

### DIFF
--- a/grails-app/taglib/com/devtrigger/grails/icu/ICUValidationTaglibTagLib.groovy
+++ b/grails-app/taglib/com/devtrigger/grails/icu/ICUValidationTaglibTagLib.groovy
@@ -30,7 +30,7 @@ class ICUValidationTaglibTagLib extends ValidationTagLib {
             if (!attrs.encodeAs && error instanceof MessageSourceResolvable) {
                 MessageSourceResolvable errorResolvable = (MessageSourceResolvable)error
                 if (errorResolvable.arguments) {
-                    error = new DefaultMessageSourceResolvable(errorResolvable.codes, encodeArgumentIfRequired(errorResolvable.arguments) as Object[], errorResolvable.defaultMessage)
+                    error = new DefaultMessageSourceResolvable(errorResolvable.codes, encodeArgumentsIfRequired(errorResolvable.arguments) as Object[], errorResolvable.defaultMessage)
                 }
             }
             try {


### PR DESCRIPTION
errorResolvable.arguments is an Object[], but when sent to encodeArgumentIfRequired, and then sent to new DefaultMessageSourceResolvable(), it ends up as an array of characters.  When printing an error message, what should look like  "Property membershipFee must be a valid number" was rendered as "Property [ must be a valid number"
